### PR TITLE
Add all tabs in current window

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -1,10 +1,9 @@
 const getSelectedTabs = () => new Promise((resolve, reject) => {
   chrome.tabs.query({
-    highlighted: true,
-    lastFocusedWindow: true,
+    currentWindow: true,
   }, (tabs) => {
       resolve(tabs);
-  })
+  });
 });
 
 const closeSelectedTabs = (tabIds) => new Promise((resolve, reject) => {


### PR DESCRIPTION
First, I love this! I've been wanting something like this for a while but didn't even realize it :D 

So as to what this PR is: Save all tabs to the group from the current window.

Perhaps I misunderstood how it should work, but this is what I expected: All tabs in the current window should be saved to the group. Currently it only saves the `highlighted` tab from the `lastFocusedWindow`. 

Feel free to close if you intended something different, but if so I'd be glad to know your workflow with it.