### PR TITLE
Re-enable outline so buttons are highlighted correctly for a11y purposes

### DIFF
--- a/popup.html
+++ b/popup.html
@@ -46,7 +46,6 @@
       }
       input[type=text] {
         -webkit-appearance: none;
-        outline: none;
         border: 1px solid #808080;
         margin: 0;
         width: 100%;
@@ -78,7 +77,6 @@
         border-radius: 3px;
         padding: 5px;
         cursor: pointer;
-        outline: none;
       }
       .primary, button:hover {
         background: #4285F4;


### PR DESCRIPTION
If you try to tab through the buttons you get no visual feedback as to which are selected. This fixes that, and also appears to fix automatically focusing the correct element (text input if no saved tab groups, or the first saved tab group).

Try using this with the ChromeVox extension to figure out if it feels right from an accessibility standpoint.